### PR TITLE
Implemented changes to support several mirrors (see #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,14 @@ environment variable will be used.
 
 ```toml
 [plugins]
-[plugins.pypi_mirror]
+[plugins.pypi_mirror.simple]
 url = "https://example.org/repository/pypi-proxy/simple/"
+
+[plugins.pypi_mirror.pypi_example]
+url = "https://pypi.example.org/simple/"
+
+[plugins.pypi_mirror.enterprise]
+url = "https://me:P4S5w0Rd@myenterprise.com/pypi/simple/"
 ```
 
 ... in [either](https://python-poetry.org/docs/configuration/) a project's

--- a/src/poetry_plugin_pypi_mirror/plugins.py
+++ b/src/poetry_plugin_pypi_mirror/plugins.py
@@ -27,7 +27,7 @@ class PyPIMirrorPlugin(Plugin):
     def activate(self, poetry: Poetry, io: IO):
 
         # Environment var overrides poetry configuration
-        pypi_mirror_url_env = os.environ.get("POETRY_PYPI_MIRROR_URL")
+        pypi_mirror_url_env = [os.environ.get("POETRY_PYPI_MIRROR_URL")]
         pypi_mirror_url_config = [ (name, details['url']) for name, details in poetry.config.\
             get("plugins", {}). \
             get("pypi_mirror", {}).values() ]


### PR DESCRIPTION
Let me know if you like the implementation. I could not properly test the plugin as I do not know how to do that but I did try to maintain your pre-existing logic, i.e. if no env variable or config is found the file still returns at line https://github.com/arcesium/poetry-plugin-pypi-mirror/blob/b650dc5e97945e0c9d52483da3a93ed08ce759ad/src/poetry_plugin_pypi_mirror/plugins.py#L36

and also I still add the first repo of the config (if several are provided) as the "PyPi" repo.