### PR TITLE
fix: Correct plugin name in plugin section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ python = "^3.8.1"
 poetry = ">= 1.3, < 1.9"
 
 [tool.poetry.plugins."poetry.plugin"]
-demo = "poetry_plugin_pypi_mirror.plugins:PyPIMirrorPlugin"
+pypi_mirror = "poetry_plugin_pypi_mirror.plugins:PyPIMirrorPlugin"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"


### PR DESCRIPTION
The plugins section of the `pyproject.toml` file should use the plugin name as the key for each entry in a specific type of plugin (c.f. https://python-poetry.org/docs/pyproject/#plugins).

The previous `demo` key originates from the [example plugin documentation](https://python-poetry.org/docs/plugins/#plugin-package). This sets the name of the [entry point](https://packaging.python.org/en/latest/specifications/entry-points/) to demo, which should actually be the plugin name.